### PR TITLE
safety: catch errant behavior before it escalates.

### DIFF
--- a/beacon.py
+++ b/beacon.py
@@ -459,11 +459,11 @@ class BeaconProbe:
 
     def _enrich_sample_freq(self, sample):
         sample['data_smooth'] = self._data_filter.value()
-        freq = sample['freq'] = self.count_to_freq(sample['data_smooth'])
+        sample['freq'] = self.count_to_freq(sample['data_smooth'])
         self._check_hardware(sample)
 
     def _enrich_sample(self, sample):
-        sample['dist'] = self.freq_to_dist(freq, sample['temp'])
+        sample['dist'] = self.freq_to_dist(sample['freq'], sample['temp'])
         pos, vel = self._get_trapq_position(sample['time'])
 
         if pos is None:
@@ -1320,6 +1320,7 @@ class BeaconEndstopWrapper:
 
         self.is_homing = True
         self.beacon._apply_threshold()
+        self.beacon._sample_async()
         clock = self._mcu.print_time_to_clock(print_time)
         rest_ticks = self._mcu.print_time_to_clock(print_time+rest_time) - clock
         self._rest_ticks = rest_ticks

--- a/beacon.py
+++ b/beacon.py
@@ -1584,7 +1584,6 @@ class BeaconMeshHelper:
             xo, yo = self.beacon.x_offset, self.beacon.y_offset
             x += xo
             y += yo
-        self.gcode.respond_info("Faulty? %f %f" % (x, y))
         for r in self.faulty_regions:
             if r.is_point_within(x, y):
                 return True

--- a/beacon.py
+++ b/beacon.py
@@ -1228,6 +1228,9 @@ class BeaconEndstopWrapper:
         # kinematic position.
         samples = self.beacon._sample_printtime_sync(5, 10)
         dist = median([s['dist'] for s in samples])
+        if math.isinf(dist):
+            raise self.beacon.printer.command_error(
+                    "Toolhead stopped below model range")
         homing_state.set_homed_position([None, None, dist])
 
     def get_mcu(self):

--- a/beacon.py
+++ b/beacon.py
@@ -513,8 +513,14 @@ class BeaconProbe:
                         updated_timer = True
 
                     self._enrich_sample_temp(sample)
-
                     temp = sample['temp']
+                    if self.model_temp is not None and not (-40 < temp < 180):
+                        msg = ("Beacon temperature sensor faulty(read %.2f C),"
+                                " disabling temperaure compensation" % (temp,))
+                        logging.error(msg)
+                        self.gcode.respond_raw("!! " + msg + "\n")
+                        self.model_temp = None
+
                     self.last_temp = temp
                     if temp:
                         self.measured_min = min(self.measured_min, temp)

--- a/beacon.py
+++ b/beacon.py
@@ -256,7 +256,7 @@ class BeaconProbe:
             # do probing move and then re-measure
             self._probing_move_to_probing_height(speed)
             (dist, samples) = self._sample(num_samples)
-        elif math.isnan(dist) and dist < 0:
+        elif math.isinf(dist) and dist < 0:
             # We were below the valid range of the model
             msg = "Attempted to probe with Beacon below calibrated model range"
             raise self.printer.command_error(msg)

--- a/beacon.py
+++ b/beacon.py
@@ -391,7 +391,7 @@ class BeaconProbe:
         f = open(fn, "w")
         f.write("freq,z,temp\n")
         for i in range(len(freq)):
-            f.write("%.5f,%.5f,%.3f\n" % (freq[i], z_ffset[i], temp[i]))
+            f.write("%.5f,%.5f,%.3f\n" % (freq[i], z_offset[i], temp[i]))
         f.close()
 
         gcmd.respond_info("Beacon calibrated at %.3f,%.3f from "


### PR DESCRIPTION
- Clamp model outputs when not within domain
- Error when entering probe below model range
- Error/warn if probing/calibrating within faulty region.
  (Can be turned from error to warning with ALLOW_FAULTY_COORDINATE=1)
- Expose current model name in get_status (gcode macros)
- Error in absence of eddy stream data
- Disable temp compensation on faulty temp sensor
- Check and report coil failures and out of spec measurements