### PR TITLE
Print new z-offset when calling Z_OFFSET_APPLY_PROBE.

### DIFF
--- a/beacon.py
+++ b/beacon.py
@@ -860,7 +860,7 @@ class BeaconProbe:
         old_offset = self.model.offset
         self.model.offset += offset
         self.model.save(self, False)
-        gcmd.respond_info("Beacon model offset has been updated\n"
+        gcmd.respond_info(f"Beacon model offset has been updated to {self.model.offset}.\n"
                 "You must run the SAVE_CONFIG command now to update the\n"
                 "printer config file and restart the printer.")
         self.model.offset = old_offset


### PR DESCRIPTION
This PR prints the new z offset value after a Z_OFFSET_APPLY_PROBE command. There was an open issue for this (https://github.com/beacon3d/beacon_klipper/issues/7) and I was looking for that same functionality, too. I hope this change to be helpful to others.