### PR TITLE
Fix: Reference self_position() axes using letters

### DIFF
--- a/beacon.py
+++ b/beacon.py
@@ -647,7 +647,7 @@ class BeaconProbe:
                     - 2.0
                     - gcmd.get_float("CEIL", self.cal_ceil)
                 )
-                self.toolhead.set_position(pos, homing_axes=[2])
+                self.toolhead.set_position(pos, homing_axes="z")
                 forced_z = True
 
             def cb(kin_pos):
@@ -2420,7 +2420,7 @@ class BeaconHomingHelper:
             move = [None, None, self.z_hop]
             if "z" not in kin_status["homed_axes"]:
                 pos[2] = 0
-                toolhead.set_position(pos, homing_axes=[2])
+                toolhead.set_position(pos, homing_axes="z")
                 toolhead.manual_move(move, self.z_hop_speed)
                 toolhead.wait_moves()
                 if hasattr(kin, "note_z_not_homed"):


### PR DESCRIPTION
As per this commit https://github.com/Klipper3d/klipper/commit/4aa550837fc170d0b77a0d461ca4f970b7bee7ae, the axes are now referenced by string letters instead of indices, this also fixes issues with beacon homing on Klipper versions after commit above.