### PR TITLE
Update TRSYNC_TIMEOUT with higher value to reduce Z homing timeouts incidents.

### DIFF
--- a/beacon.py
+++ b/beacon.py
@@ -2087,7 +2087,7 @@ class BeaconTempWrapper:
         }
 
 
-TRSYNC_TIMEOUT = 0.025
+TRSYNC_TIMEOUT = 0.05
 
 
 class BeaconEndstopShared:


### PR DESCRIPTION
Original value of 0.025 is causing frequent timeouts when Z homing. 

Changing it to 0.05 resolves the problem with no visible side effects.