### PR TITLE
make run_probe accept extra args for compatibility

### DIFF
--- a/beacon.py
+++ b/beacon.py
@@ -2056,7 +2056,7 @@ class BeaconProbeWrapper:
     def get_lift_speed(self, gcmd=None):
         return self.beacon.get_lift_speed(gcmd)
 
-    def run_probe(self, gcmd):
+    def run_probe(self, gcmd, *args, **kwargs):
         result = self.beacon.run_probe(gcmd)
         if self.results is not None:
             self.results.append(result)


### PR DESCRIPTION
Kalico now calls the probe API as `probe.run_probe(gcmd, retry_session)` (passing an extra positional argument). Beacon’s run_probe() currently only accepts (gcmd), which causes a runtime exception when Beacon is used as the active probe object:
```python
TypeError: run_probe() takes 2 positional arguments but 3 were given
```
This PR updates Beacon’s run_probe() signature to accept and ignore additional `*args / **kwargs`, restoring compatibility with Kalico and making Beacon resilient to other forks/modules that extend the probe API signature in the future.